### PR TITLE
Fix code style for PSR12 standard

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="PHP_CodeSniffer">
     <description>The coding standard for our project.</description>
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <file>src</file>
     <file>tests</file>

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 abstract class AbstractApi
 {
     public string $endpoint;
-    
+
     private Client $client;
 
     public function __construct(Client $client)
@@ -26,24 +26,24 @@ abstract class AbstractApi
     {
         return $this->client;
     }
-    
+
     protected function makeHttpRequest(string $url, RequestDTOInterface $requestDTO): ResponseInterface
     {
         $request = $this->client->getHttpClientBuilder()->getRequestFactory()->createRequest('POST', $url);
-        
+
         $privateKey = $this->client->getPrivateKey();
-        
+
         $passphrase = $this->client->getPassphrase();
 
         $signature = Signatory::sign((string)$requestDTO, $privateKey, $passphrase);
-        
+
         $body = RequestMediator::generateRequestRawBody($requestDTO->withBased64Signature($signature));
-        
+
         $request = $request->withBody($this->client->getHttpClientBuilder()->getStreamFactory()->createStream($body));
-        
+
         return $this->client->getHttpClient()->sendRequest($request);
     }
-    
+
     protected function setEndpoint(string $endpoint): void
     {
         $this->endpoint = $endpoint;

--- a/src/Api/Cancel.php
+++ b/src/Api/Cancel.php
@@ -14,9 +14,9 @@ class Cancel extends AbstractApi
     public function __invoke(RequestAdapter $requestAdapter): ResponseDTOInterface
     {
         $httpResponse = $this->makeHttpRequest($this->endpoint, $requestAdapter->toRequestDTO());
-        
+
         $responseDTO = new CancelResponseDTO($httpResponse);
-        
+
         return (new Response($this->getClient()))
             ->get($responseDTO)
             ->toDTO()

--- a/src/Api/Init.php
+++ b/src/Api/Init.php
@@ -15,9 +15,9 @@ class Init extends AbstractApi
     public function __invoke(RequestAdapter $requestAdapter): ResponseDTOInterface
     {
         $httpResponse = $this->makeHttpRequest($this->endpoint, $requestAdapter->toRequestDTO());
-        
+
         $responseDTO = new InitResponseDTO($httpResponse);
-        
+
         return (new Response($this->getClient()))
             ->get($responseDTO)
             ->validate()

--- a/src/Api/Result.php
+++ b/src/Api/Result.php
@@ -15,9 +15,9 @@ class Result extends AbstractApi
     public function __invoke(RequestAdapter $requestAdapter): ResponseDTOInterface
     {
         $httpResponse = $this->makeHttpRequest($this->endpoint, $requestAdapter->toRequestDTO());
-        
+
         $responseDTO = new ResultResponseDTO($httpResponse);
-        
+
         return (new Response($this->getClient()))
             ->get($responseDTO)
             ->validate()

--- a/src/Api/Seal.php
+++ b/src/Api/Seal.php
@@ -14,9 +14,9 @@ class Seal extends AbstractApi
     public function __invoke(RequestAdapter $requestAdapter): ResponseDTOInterface
     {
         $httpResponse = $this->makeHttpRequest($this->endpoint, $requestAdapter->toRequestDTO());
-        
+
         $responseDTO = new SealResponseDTO($httpResponse);
-        
+
         return (new Response($this->getClient()))
             ->get($responseDTO)
             ->validate()

--- a/src/Api/Timestamp.php
+++ b/src/Api/Timestamp.php
@@ -14,9 +14,9 @@ class Timestamp extends AbstractApi
     public function __invoke(RequestAdapter $requestAdapter): ResponseDTOInterface
     {
         $httpResponse = $this->makeHttpRequest($this->endpoint, $requestAdapter->toRequestDTO());
-        
+
         $responseDTO = new TimestampResponseDTO($httpResponse);
-        
+
         return (new Response($this->getClient()))
             ->get($responseDTO)
             ->validate()

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,17 +30,17 @@ use Psr\Http\Message\ResponseInterface;
 class Client
 {
     private Builder $httpClientBuilder;
-    
+
     private string $clientId;
-    
+
     private string $privateKey;
-    
+
     private string $passphrase;
-    
+
     private string $publicKey;
-    
+
     private string $apiEndpointUrl = '';
-    
+
     public function __construct(Builder $httpClientBuilder = null)
     {
         $this->httpClientBuilder = $builder = $httpClientBuilder ?? new Builder();
@@ -62,45 +62,45 @@ class Client
         Configuration $configuration
     ): ResponseDTOInterface {
         $this->httpClientBuilder->addPlugin(new SoapRequest('InitSigning'));
-        
+
         $initRequestAdapter = new InitRequestAdapter($this, $signer, $file, $signatureConfiguration, $configuration);
-        
+
         return (new Init($this))($initRequestAdapter);
     }
 
     public function result(Transaction $transaction): ResponseDTOInterface
     {
         $this->httpClientBuilder->addPlugin(new SoapRequest('SigningResult'));
-        
+
         $resultRequestAdapter = new ResultRequestAdapter($this, $transaction);
-        
+
         return (new Result($this))($resultRequestAdapter);
     }
 
     public function cancel(Transaction $transaction): ResponseDTOInterface
     {
         $this->httpClientBuilder->addPlugin(new SoapRequest('SigningCancel'));
-        
+
         $resultRequestAdapter = new CancelRequestAdapter($this, $transaction);
-        
+
         return (new Cancel($this))($resultRequestAdapter);
     }
-    
+
     public function timestamp(Signer $signer, File $file, Configuration $configuration): ResponseDTOInterface
     {
         $this->httpClientBuilder->addPlugin(new SoapRequest('Timestamp'));
-        
+
         $timestampRequestAdapter = new TimestampRequestAdapter($this, $signer, $file, $configuration);
-        
+
         return (new Timestamp($this))($timestampRequestAdapter);
     }
-    
+
     public function seal(File $file): ResponseDTOInterface
     {
         $this->httpClientBuilder->addPlugin(new SoapRequest('Seal'));
-        
+
         $sealRequestAdapter = new SealRequestAdapter($this, $file);
-        
+
         return (new Seal($this))($sealRequestAdapter);
     }
 
@@ -117,28 +117,28 @@ class Client
         $this->passphrase = $passphrase;
         $this->publicKey = $publicKey;
     }
-    
+
     public function getApiEndpointUrl(): string
     {
         return $this->apiEndpointUrl;
     }
-    
+
     public function getClientId(): string
     {
         return $this->clientId;
     }
-    
-    
+
+
     public function getPrivateKey(): string
     {
         return $this->privateKey;
     }
-    
+
     public function getPublicKey(): string
     {
         return $this->publicKey;
     }
-    
+
     public function getPassphrase(): string
     {
         return $this->passphrase;

--- a/src/Entity/AcceptableInfrastructure.php
+++ b/src/Entity/AcceptableInfrastructure.php
@@ -10,7 +10,7 @@ final class AcceptableInfrastructure extends AbstractEntity implements EntityInt
      * @var string
   */
     public const MOBILE = 'Mobile';
-    
+
     /**
      * @var string
   */

--- a/src/Entity/Configuration.php
+++ b/src/Entity/Configuration.php
@@ -9,52 +9,52 @@ use RegistruCentras\OneSign\Entity\EntityInterface;
 final class Configuration extends AbstractEntity implements EntityInterface
 {
     protected ?string $locale = null;
-    
+
     protected string $responseUrl;
-    
+
     protected ?string $acceptableInfrastructure  = null;
-    
+
     protected string $signingType;
-    
+
     public function setLocale(string $locale): EntityInterface
     {
         $this->locale = $locale;
         return $this;
     }
-    
+
     public function getLocale(): ?string
     {
         return $this->locale;
     }
-    
+
     public function setResponseUrl(string $responseUrl): EntityInterface
     {
         $this->responseUrl = $responseUrl;
         return $this;
     }
-    
+
     public function getResponseUrl(): string
     {
         return $this->responseUrl;
     }
-    
+
     public function setAcceptableInfrastructure(?string $acceptableInfrastructure): EntityInterface
     {
         $this->acceptableInfrastructure = $acceptableInfrastructure;
         return $this;
     }
-    
+
     public function getAcceptableInfrastructure(): ?string
     {
         return $this->acceptableInfrastructure;
     }
-    
+
     public function setSigningType(string $signingType): EntityInterface
     {
         $this->signingType = $signingType;
         return $this;
     }
-    
+
     public function getSigningType(): string
     {
         return $this->signingType;

--- a/src/Entity/EntityInterface.php
+++ b/src/Entity/EntityInterface.php
@@ -6,5 +6,5 @@ namespace RegistruCentras\OneSign\Entity;
 
 interface EntityInterface
 {
-    
+
 }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -9,26 +9,26 @@ use RegistruCentras\OneSign\Entity\EntityInterface;
 final class File extends AbstractEntity implements EntityInterface
 {
     protected ?string $name = null;
-    
+
     protected ?string $content = null;
-    
+
     public function setName(string $name): EntityInterface
     {
         $this->name = $name;
         return $this;
     }
-    
+
     public function getName(): ?string
     {
         return $this->name;
     }
-    
+
     public function setContent(string $content): EntityInterface
     {
         $this->content = $content;
         return $this;
     }
-    
+
     public function getContent(): ?string
     {
         return $this->content;

--- a/src/Entity/Locale.php
+++ b/src/Entity/Locale.php
@@ -10,7 +10,7 @@ final class Locale extends AbstractEntity implements EntityInterface
      * @var string
   */
     public const LT = 'LT';
-    
+
     /**
      * @var string
   */

--- a/src/Entity/SignatureConfiguration.php
+++ b/src/Entity/SignatureConfiguration.php
@@ -10,26 +10,26 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties;
 final class SignatureConfiguration extends AbstractEntity
 {
     protected ?Metadata $metadata = null;
-    
+
     protected ?DisplayProperties $displayProperties = null;
-    
+
     public function setMetadata(Metadata $metadata): SignatureConfiguration
     {
         $this->metadata = $metadata;
         return $this;
     }
-    
+
     public function getMetadata(): ?Metadata
     {
         return $this->metadata;
     }
-    
+
     public function setDisplayProperties(DisplayProperties $displayProperties): SignatureConfiguration
     {
         $this->displayProperties = $displayProperties;
         return $this;
     }
-    
+
     public function getDisplayProperties(): ?displayProperties
     {
         return $this->displayProperties;

--- a/src/Entity/SignatureConfiguration/DisplayProperties.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties.php
@@ -7,10 +7,10 @@ namespace RegistruCentras\OneSign\Entity\SignatureConfiguration;
 interface DisplayProperties
 {
     public function getPosition(): string;
-    
+
     public function getDisplayValidity(): bool;
-    
+
     public function getSignatureImageUrl(): ?string;
-    
+
     public function getBackgroundImageUrl(): ?string;
 }

--- a/src/Entity/SignatureConfiguration/DisplayProperties/AbsolutePosition.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/AbsolutePosition.php
@@ -14,15 +14,15 @@ final class AbsolutePosition implements DisplayProperties
     use WithVisibleSignature;
     use WithSignatureSize;
     use WithSignatureInPage;
-    
+
     private string $x;
-    
+
     private string $y;
-    
+
     private string $width;
-    
+
     private string $height;
-    
+
     public function getPosition(): string
     {
         $page = $this->getPage();
@@ -30,27 +30,27 @@ final class AbsolutePosition implements DisplayProperties
         $positionY = $this->getY();
         $width = $this->getWidth();
         $height = $this->getHeight();
-        
+
         return \sprintf('absolute, %s, %s, %s, %s, %s', $page, $positionX, $positionY, $width, $height);
     }
-    
+
     public function setX(string $x): DisplayProperties
     {
         $this->x = $x;
         return $this;
     }
-    
+
     public function getX(): string
     {
         return $this->x;
     }
-    
+
     public function setY(string $y): DisplayProperties
     {
         $this->y = $y;
         return $this;
     }
-    
+
     public function getY(): string
     {
         return $this->y;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/HiddenPosition.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/HiddenPosition.php
@@ -10,7 +10,7 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties\Trai
 final class HiddenPosition implements DisplayProperties
 {
     use WithNoVisibleSignature;
-    
+
     public function getPosition(): string
     {
         return 'hidden';

--- a/src/Entity/SignatureConfiguration/DisplayProperties/NamedPosition.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/NamedPosition.php
@@ -10,20 +10,20 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties\Trai
 final class NamedPosition implements DisplayProperties
 {
     use WithVisibleSignature;
-    
+
     private string $fieldName;
-    
+
     public function getPosition(): string
     {
         return \sprintf('named, %s', $this->getFieldName());
     }
-     
+
     public function setFieldName(string $fieldName): DisplayProperties
     {
         $this->fieldName = $fieldName;
         return $this;
     }
-    
+
     public function getFieldName(): string
     {
         return $this->fieldName;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition.php
@@ -14,11 +14,11 @@ final class RelativePosition implements DisplayProperties
     use WithVisibleSignature;
     use WithSignatureSize;
     use WithSignatureInPage;
-    
+
     private float $x;
-    
+
     private float $y;
-    
+
     public function getPosition(): string
     {
         $page = $this->getPage();
@@ -26,27 +26,27 @@ final class RelativePosition implements DisplayProperties
         $positionY = $this->getY();
         $width = $this->getWidth();
         $height = $this->getHeight();
-        
+
         return \sprintf('relative, %s, %.3f, %.3f, %s, %s', $page, $positionX, $positionY, $width, $height);
     }
-    
+
     public function setX(float $x): DisplayProperties
     {
         $this->x = $x;
         return $this;
     }
-    
+
     public function getX(): float
     {
         return $this->x;
     }
-    
+
     public function setY(float $y): DisplayProperties
     {
         $this->y = $y;
         return $this;
     }
-    
+
     public function getY(): float
     {
         return $this->y;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition/RelativeX.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition/RelativeX.php
@@ -10,7 +10,7 @@ final class RelativeX
      * @var int
      */
     public const LEFT = 0;
-    
+
     /**
      * @var float
    */

--- a/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition/RelativeY.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/RelativePosition/RelativeY.php
@@ -10,7 +10,7 @@ final class RelativeY
      * @var int
      */
     public const TOP = 0;
-    
+
     /**
      * @var float
    */

--- a/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithNoVisibleSignature.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithNoVisibleSignature.php
@@ -12,12 +12,12 @@ trait WithNoVisibleSignature
     {
         return false;
     }
-     
+
     public function getSignatureImageUrl(): ?string
     {
         return null;
     }
-     
+
     public function getBackgroundImageUrl(): ?string
     {
         return null;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithSignatureInPage.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithSignatureInPage.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties;
 trait WithSignatureInPage
 {
     private int $page;
-    
+
     public function setPage(int $page): DisplayProperties
     {
         $this->page = $page;
         return $this;
     }
-    
+
     public function getPage(): int
     {
         return $this->page;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithSignatureSize.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithSignatureSize.php
@@ -9,26 +9,26 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties;
 trait WithSignatureSize
 {
     private string $width;
-    
+
     private string $height;
-    
+
     public function setWidth(string $width): DisplayProperties
     {
         $this->width = $width;
         return $this;
     }
-    
+
     public function getWidth(): string
     {
         return $this->width;
     }
-    
+
     public function setHeight(string $height): DisplayProperties
     {
         $this->height = $height;
         return $this;
     }
-    
+
     public function getHeight(): string
     {
         return $this->height;

--- a/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithVisibleSignature.php
+++ b/src/Entity/SignatureConfiguration/DisplayProperties/Traits/WithVisibleSignature.php
@@ -9,39 +9,39 @@ use RegistruCentras\OneSign\Entity\SignatureConfiguration\DisplayProperties;
 trait WithVisibleSignature
 {
     private bool $displayValidity = false;
-    
+
     private ?string $signatureImageUrl = null;
-    
+
     private ?string $backgroundImageUrl = null;
-    
+
     public function setDisplayValidity(bool $displayValidity): DisplayProperties
     {
         $this->displayValidity = $displayValidity;
         return $this;
     }
-    
+
     public function getDisplayValidity(): bool
     {
         return $this->displayValidity;
     }
-    
+
     public function setSignatureImageUrl(string $signatureImageUrl): DisplayProperties
     {
         $this->signatureImageUrl = $signatureImageUrl;
         return $this;
     }
-     
+
     public function getSignatureImageUrl(): ?string
     {
         return $this->signatureImageUrl;
     }
-     
+
     public function setBackgroundImageUrl(string $backgroundImageUrl): DisplayProperties
     {
         $this->backgroundImageUrl = $backgroundImageUrl;
         return $this;
     }
-    
+
     public function getBackgroundImageUrl(): ?string
     {
         return $this->backgroundImageUrl;

--- a/src/Entity/SignatureConfiguration/Metadata.php
+++ b/src/Entity/SignatureConfiguration/Metadata.php
@@ -7,42 +7,42 @@ namespace RegistruCentras\OneSign\Entity\SignatureConfiguration;
 final class Metadata
 {
     private ?string $reason = null;
-    
+
     private ?string $location = null;
-    
+
     private ?string $contact = null;
-    
+
     public function setReason(?string $reason): Metadata
     {
         $this->reason = $reason;
-        
+
         return $this;
     }
-    
+
     public function getReason(): ?string
     {
         return $this->reason;
     }
-    
+
     public function setLocation(?string $location): Metadata
     {
         $this->location = $location;
-        
+
         return $this;
     }
-    
+
     public function getLocation(): ?string
     {
         return $this->location;
     }
-    
+
     public function setContact(?string $contact): Metadata
     {
         $this->contact = $contact;
-        
+
         return $this;
     }
-    
+
     public function getContact(): ?string
     {
         return $this->contact;

--- a/src/Entity/Signer.php
+++ b/src/Entity/Signer.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\Entity\EntityInterface;
 final class Signer extends AbstractEntity implements EntityInterface
 {
     protected ?string $personalCode = null;
-    
+
     public function setPersonalCode(string $personalCode): EntityInterface
     {
         $this->personalCode = $personalCode;
         return $this;
     }
-    
+
     public function getPersonalCode(): ?string
     {
         return $this->personalCode;

--- a/src/Entity/SigningType.php
+++ b/src/Entity/SigningType.php
@@ -10,12 +10,12 @@ final class SigningType extends AbstractEntity implements EntityInterface
      * @var string
   */
     public const SIGNATURE = 'Signature';
-    
+
     /**
      * @var string
      */
     public const SIGNATURE_WITH_TIMESTAMP = 'SignatureWithTimestamp';
-    
+
     /**
      * @var string
      */

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\Entity\EntityInterface;
 final class Transaction extends AbstractEntity implements EntityInterface
 {
     protected string $transactionId;
-    
+
     public function setTransactionId(string $transactionId): EntityInterface
     {
         $this->transactionId = $transactionId;
         return $this;
     }
-    
+
     public function getTransactionId(): ?string
     {
         return $this->transactionId;

--- a/src/HttpClient/Builder.php
+++ b/src/HttpClient/Builder.php
@@ -78,7 +78,7 @@ final class Builder
     public function addCache(CacheItemPoolInterface $cachePool, array $config = []): void
     {
         $headerTypes = ['Authorization', 'Cookie', 'Accept', 'Content-type'];
-        
+
         if (!isset($config['cache_key_generator'])) {
             $config['cache_key_generator'] = new HeaderCacheKeyGenerator($headerTypes);
         }
@@ -92,16 +92,16 @@ final class Builder
         $this->cachePlugin = null;
         $this->pluginClient = null;
     }
-    
+
     public function getRequestFactory(): RequestFactoryInterface
     {
-        
+
         return $this->requestFactory;
     }
-    
+
     public function getStreamFactory(): StreamFactoryInterface
     {
-        
+
         return $this->streamFactory;
     }
 }

--- a/src/HttpClient/DTO/Request/Adapter/CancelRequestAdapter.php
+++ b/src/HttpClient/DTO/Request/Adapter/CancelRequestAdapter.php
@@ -13,18 +13,18 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\CancelRequestDTO;
 final class CancelRequestAdapter implements RequestAdapter
 {
     private Client $client;
-    
+
     private Transaction $transaction;
-    
+
     public function __construct(Client $client, Transaction $transaction)
     {
         $this->client = $client;
         $this->transaction = $transaction;
     }
-    
+
     public function toRequestDTO(): RequestDTOInterface
     {
-        
+
         return (new CancelRequestDTO())
             ->setClientId($this->client->getClientId())
             ->setTransactionId($this->transaction->getTransactionId());

--- a/src/HttpClient/DTO/Request/Adapter/InitRequestAdapter.php
+++ b/src/HttpClient/DTO/Request/Adapter/InitRequestAdapter.php
@@ -21,15 +21,15 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\Init\SignatureDisplayProperti
 final class InitRequestAdapter implements RequestAdapter
 {
     private Client $client;
-    
+
     private Signer $signer;
-    
+
     private File $file;
-    
+
     private SignatureConfiguration $signatureConfiguration;
-    
+
     private Configuration $configuration;
-    
+
     public function __construct(
         Client $client,
         Signer $signer,
@@ -43,10 +43,10 @@ final class InitRequestAdapter implements RequestAdapter
         $this->signatureConfiguration = $signatureConfiguration;
         $this->configuration = $configuration;
     }
-    
+
     public function toRequestDTO(): RequestDTOInterface
     {
-        
+
         $clientInfo = (new ClientInfoDTO())
             ->setClientId($this->client->getClientId())
             ->setSignerPersonalCode($this->signer->getPersonalCode())
@@ -54,29 +54,29 @@ final class InitRequestAdapter implements RequestAdapter
             ->setResponseUrl($this->configuration->getResponseUrl())
             ->setAcceptableInfrastructure($this->configuration->getAcceptableInfrastructure())
             ;
-            
+
         $file = (new FileDTO())
             ->setFileName($this->file->getName())
             ->setContent($this->file->getContent())
             ;
-        
-        
+
+
         $initRequestDTO = (new InitRequestDTO())
             ->setClientInfo($clientInfo)
             ->setFile($file->withFileDigest(Files::generateFileDigest($file->getContent())))
             ->setSigningType($this->configuration->getSigningType())
             ;
-        
+
         if ($this->signatureConfiguration->getMetadata() !== null) {
             $metadata = (new SignatureMetadataDTO())
                 ->setReason($this->signatureConfiguration->getMetadata()->getReason())
                 ->setLocation($this->signatureConfiguration->getMetadata()->getLocation())
                 ->setContact($this->signatureConfiguration->getMetadata()->getContact())
                 ;
-                
+
             $initRequestDTO = $initRequestDTO->withSignatureMetadata($metadata);
         }
-        
+
         if ($this->signatureConfiguration->getDisplayProperties() !== null) {
             $signatureDisplayProperties = (new SignatureDisplayPropertiesDTO())
                 ->setPosition($this->signatureConfiguration->getDisplayProperties()->getPosition())
@@ -84,10 +84,10 @@ final class InitRequestAdapter implements RequestAdapter
                 ->setSignatureImageUrl($this->signatureConfiguration->getDisplayProperties()->getSignatureImageUrl())
                 ->setBackgroundImageUrl($this->signatureConfiguration->getDisplayProperties()->getBackgroundImageUrl())
                 ;
-                
+
             $initRequestDTO = $initRequestDTO->withSignatureDisplayProperties($signatureDisplayProperties);
         }
-        
+
         return $initRequestDTO;
     }
 }

--- a/src/HttpClient/DTO/Request/Adapter/ResultRequestAdapter.php
+++ b/src/HttpClient/DTO/Request/Adapter/ResultRequestAdapter.php
@@ -13,18 +13,18 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\ResultRequestDTO;
 final class ResultRequestAdapter implements RequestAdapter
 {
     private Client $client;
-    
+
     private Transaction $transaction;
-    
+
     public function __construct(Client $client, Transaction $transaction)
     {
         $this->client = $client;
         $this->transaction = $transaction;
     }
-    
+
     public function toRequestDTO(): RequestDTOInterface
     {
-        
+
         return (new ResultRequestDTO())
             ->setClientId($this->client->getClientId())
             ->setTransactionId($this->transaction->getTransactionId());

--- a/src/HttpClient/DTO/Request/Adapter/SealRequestAdapter.php
+++ b/src/HttpClient/DTO/Request/Adapter/SealRequestAdapter.php
@@ -19,27 +19,27 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\Seal\FileDTO;
 final class SealRequestAdapter implements RequestAdapter
 {
     private Client $client;
-    
+
     private File $file;
-    
+
     public function __construct(Client $client, File $file)
     {
         $this->client = $client;
         $this->file = $file;
     }
-    
+
     public function toRequestDTO(): RequestDTOInterface
     {
-        
+
         $clientInfo = (new ClientInfoDTO())
             ->setClientId($this->client->getClientId())
             ;
-            
+
         $file = (new FileDTO())
             ->setFileName($this->file->getName())
             ->setContent($this->file->getContent())
             ;
-        
+
         return (new SealRequestDTO())
             ->setClientInfo($clientInfo)
             ->setFile($file->withFileDigest(Files::generateFileDigest($file->getContent())));

--- a/src/HttpClient/DTO/Request/Adapter/TimestampRequestAdapter.php
+++ b/src/HttpClient/DTO/Request/Adapter/TimestampRequestAdapter.php
@@ -18,13 +18,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\Timestamp\FileDTO;
 final class TimestampRequestAdapter implements RequestAdapter
 {
     private Client $client;
-    
+
     private Signer $signer;
-    
+
     private File $file;
-    
+
     private Configuration $configuration;
-    
+
     public function __construct(Client $client, Signer $signer, File $file, Configuration $configuration)
     {
         $this->client = $client;
@@ -32,21 +32,21 @@ final class TimestampRequestAdapter implements RequestAdapter
         $this->file = $file;
         $this->configuration = $configuration;
     }
-    
+
     public function toRequestDTO(): RequestDTOInterface
     {
-        
+
         $clientInfo = (new ClientInfoDTO())
             ->setClientId($this->client->getClientId())
             ->setSignerPersonalCode($this->signer->getPersonalCode())
             ->setLocale($this->configuration->getLocale())
             ;
-            
+
         $file = (new FileDTO())
             ->setFileName($this->file->getName())
             ->setContent($this->file->getContent())
             ;
-        
+
         return (new TimestampRequestDTO())
             ->setClientInfo($clientInfo)
             ->setFile($file->withFileDigest(Files::generateFileDigest($file->getContent())));

--- a/src/HttpClient/DTO/Request/CancelRequestDTO.php
+++ b/src/HttpClient/DTO/Request/CancelRequestDTO.php
@@ -15,7 +15,7 @@ final class CancelRequestDTO implements RequestDTOInterface
     use WithClientDTO;
     use WithTransactionDTO;
     use WithSignatureDTO;
-    
+
     public function __toString(): string
     {
         return \sprintf(
@@ -24,7 +24,7 @@ final class CancelRequestDTO implements RequestDTOInterface
             (string)$this->getTransactionId()
         );
     }
-    
+
     public function toArray(): array
     {
         return [

--- a/src/HttpClient/DTO/Request/Init/ClientInfoDTO.php
+++ b/src/HttpClient/DTO/Request/Init/ClientInfoDTO.php
@@ -14,7 +14,7 @@ final class ClientInfoDTO implements RequestDTOInterface
     use WithClientInfoDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/Init/FileDTO.php
+++ b/src/HttpClient/DTO/Request/Init/FileDTO.php
@@ -14,7 +14,7 @@ final class FileDTO implements RequestDTOInterface
     use WithFileDTO;
     use WithSignatureDTO;
     use StringableWithFile;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/Init/SignatureDisplayPropertiesDTO.php
+++ b/src/HttpClient/DTO/Request/Init/SignatureDisplayPropertiesDTO.php
@@ -14,7 +14,7 @@ final class SignatureDisplayPropertiesDTO implements RequestDTOInterface
     use WithSignatureDisplayPropertiesDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/Init/SignatureMetadataDTO.php
+++ b/src/HttpClient/DTO/Request/Init/SignatureMetadataDTO.php
@@ -14,7 +14,7 @@ final class SignatureMetadataDTO implements RequestDTOInterface
     use WithSignatureMetadataDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/InitRequestDTO.php
+++ b/src/HttpClient/DTO/Request/InitRequestDTO.php
@@ -17,75 +17,75 @@ final class InitRequestDTO implements RequestDTOInterface
 {
     use WithSignatureDTO;
     use WithSigningTypeDTO;
-    
+
     private ClientInfoDTO $clientInfo;
-    
+
     private ?MetadataDTO $metadata = null;
-    
+
     private ?DisplayPropertiesDTO $displayProperties = null;
-    
+
     private FileDTO $file;
-    
+
     public function setClientInfo(ClientInfoDTO $clientInfo): RequestDTOInterface
     {
         $this->clientInfo = $clientInfo;
         return $this;
     }
-    
+
     public function getClientInfo(): ClientInfoDTO
     {
         return $this->clientInfo;
     }
-    
+
     public function setSignatureMetadata(MetadataDTO $metadata): RequestDTOInterface
     {
         $this->metadata = $metadata;
         return $this;
     }
-    
+
     public function getSignatureMetadata(): ?MetadataDTO
     {
         return $this->metadata;
     }
-    
+
     public function withSignatureMetadata(MetadataDTO $metadata): RequestDTOInterface
     {
         $dto = clone $this;
-        
+
         $dto->metadata = $metadata;
         return $dto;
     }
-    
+
     public function setSignatureDisplayProperties(DisplayPropertiesDTO $displayProperties): RequestDTOInterface
     {
         $this->displayProperties = $displayProperties;
         return $this;
     }
-    
+
     public function getSignatureDisplayProperties(): ?DisplayPropertiesDTO
     {
         return $this->displayProperties;
     }
-    
+
     public function withSignatureDisplayProperties(DisplayPropertiesDTO $displayProperties): RequestDTOInterface
     {
         $dto = clone $this;
-        
+
         $dto->displayProperties = $displayProperties;
         return $dto;
     }
-    
+
     public function setFile(FileDTO $file): RequestDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function __toString(): string
     {
         return \sprintf(
@@ -97,12 +97,12 @@ final class InitRequestDTO implements RequestDTOInterface
             (string)$this->file
         );
     }
-    
+
     public function toArray(): array
     {
         $metadata = !\is_null($this->metadata) ? $this->metadata->toArray() : null;
         $displayProperties = !\is_null($this->displayProperties) ? $this->displayProperties->toArray() : null;
-        
+
         return [
             RequestMediator::elementWithNamespace('InitOneSignRequest') => \array_filter([
                 RequestMediator::elementWithNamespace('clientInfo') => $this->clientInfo->toArray(),

--- a/src/HttpClient/DTO/Request/ResultRequestDTO.php
+++ b/src/HttpClient/DTO/Request/ResultRequestDTO.php
@@ -15,7 +15,7 @@ final class ResultRequestDTO implements RequestDTOInterface
     use WithClientDTO;
     use WithTransactionDTO;
     use WithSignatureDTO;
-    
+
     public function __toString(): string
     {
         return \sprintf(
@@ -24,7 +24,7 @@ final class ResultRequestDTO implements RequestDTOInterface
             (string)$this->getTransactionId()
         );
     }
-    
+
     public function toArray(): array
     {
         return [

--- a/src/HttpClient/DTO/Request/Seal/ClientInfoDTO.php
+++ b/src/HttpClient/DTO/Request/Seal/ClientInfoDTO.php
@@ -14,7 +14,7 @@ final class ClientInfoDTO implements RequestDTOInterface
     use WithClientDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/Seal/FileDTO.php
+++ b/src/HttpClient/DTO/Request/Seal/FileDTO.php
@@ -14,7 +14,7 @@ final class FileDTO implements RequestDTOInterface
     use WithFileDTO;
     use WithSignatureDTO;
     use StringableWithFile;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/SealRequestDTO.php
+++ b/src/HttpClient/DTO/Request/SealRequestDTO.php
@@ -13,33 +13,33 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\Traits\WithSignatureDTO;
 final class SealRequestDTO implements RequestDTOInterface
 {
     use WithSignatureDTO;
-    
+
     private RequestDTOInterface $clientInfo;
-    
+
     private FileDTO $file;
-    
+
     public function setClientInfo(RequestDTOInterface $clientInfo): RequestDTOInterface
     {
         $this->clientInfo = $clientInfo;
         return $this;
     }
-    
+
     public function getClientInfo(): RequestDTOInterface
     {
         return $this->clientInfo;
     }
-    
+
     public function setFile(FileDTO $file): RequestDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function __toString(): string
     {
         return \sprintf(
@@ -48,7 +48,7 @@ final class SealRequestDTO implements RequestDTOInterface
             (string)$this->file
         );
     }
-    
+
     public function toArray(): array
     {
         return [

--- a/src/HttpClient/DTO/Request/Timestamp/ClientInfoDTO.php
+++ b/src/HttpClient/DTO/Request/Timestamp/ClientInfoDTO.php
@@ -16,20 +16,20 @@ final class ClientInfoDTO implements RequestDTOInterface
     use WithLocaleDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     private ?string $signerPersonalCode = null;
-    
+
     public function setSignerPersonalCode(?string $signerPersonalCode): RequestDTOInterface
     {
         $this->signerPersonalCode = $signerPersonalCode;
         return $this;
     }
-    
+
     public function getSignerPersonalCode(): ?string
     {
         return $this->signerPersonalCode;
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/Timestamp/FileDTO.php
+++ b/src/HttpClient/DTO/Request/Timestamp/FileDTO.php
@@ -14,7 +14,7 @@ final class FileDTO implements RequestDTOInterface
     use WithFileDTO;
     use WithSignatureDTO;
     use StringableWithFile;
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Request/TimestampRequestDTO.php
+++ b/src/HttpClient/DTO/Request/TimestampRequestDTO.php
@@ -13,33 +13,33 @@ use RegistruCentras\OneSign\HttpClient\DTO\Request\Traits\WithSignatureDTO;
 final class TimestampRequestDTO implements RequestDTOInterface
 {
     use WithSignatureDTO;
-    
+
     private ClientInfoDTO $clientInfo;
-    
+
     private FileDTO $file;
-    
+
     public function setClientInfo(ClientInfoDTO $clientInfo): RequestDTOInterface
     {
         $this->clientInfo = $clientInfo;
         return $this;
     }
-    
+
     public function getClientInfo(): ClientInfoDTO
     {
         return $this->clientInfo;
     }
-    
+
     public function setFile(FileDTO $file): RequestDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function __toString(): string
     {
         return \sprintf(
@@ -48,7 +48,7 @@ final class TimestampRequestDTO implements RequestDTOInterface
             (string)$this->file
         );
     }
-    
+
     public function toArray(): array
     {
         return [

--- a/src/HttpClient/DTO/Request/Traits/Stringable.php
+++ b/src/HttpClient/DTO/Request/Traits/Stringable.php
@@ -10,9 +10,9 @@ trait Stringable
 {
     public function __toString(): string
     {
-        
+
         $arrayToXml = new ArrayToXml($this->toArray());
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
 }

--- a/src/HttpClient/DTO/Request/Traits/StringableWithFile.php
+++ b/src/HttpClient/DTO/Request/Traits/StringableWithFile.php
@@ -10,13 +10,13 @@ trait StringableWithFile
 {
     public function __toString(): string
     {
-        
+
         $array = $this->toArray();
-        
+
         unset($array['content']);
-        
+
         $arrayToXml = new ArrayToXml($array);
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
 }

--- a/src/HttpClient/DTO/Request/Traits/WithClientDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithClientDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithClientDTO
 {
     private string $clientId;
-    
+
     public function setClientId(string $clientId): RequestDTOInterface
     {
         $this->clientId = $clientId;
         return $this;
     }
-    
+
     public function getClientId(): ?string
     {
         return $this->clientId;

--- a/src/HttpClient/DTO/Request/Traits/WithClientInfoDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithClientInfoDTO.php
@@ -9,65 +9,65 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithClientInfoDTO
 {
     private string $clientId;
-    
+
     private ?string $signerPersonalCode = null;
-    
+
     private ?string $locale = null;
-    
+
     private string $responseUrl;
-    
+
     private ?string $acceptableInfrastructure = null;
-    
+
     public function setClientId(string $clientId): RequestDTOInterface
     {
         $this->clientId = $clientId;
         return $this;
     }
-    
+
     public function getClientId(): string
     {
         return $this->clientId;
     }
-    
+
     public function setSignerPersonalCode(?string $signerPersonalCode): RequestDTOInterface
     {
         $this->signerPersonalCode = $signerPersonalCode;
         return $this;
     }
-    
+
     public function getSignerPersonalCode(): ?string
     {
         return $this->signerPersonalCode;
     }
-    
+
     public function setLocale(?string $locale): RequestDTOInterface
     {
         $this->locale = $locale;
         return $this;
     }
-    
+
     public function getLocale(): ?string
     {
         return $this->locale;
     }
-    
+
     public function setResponseUrl(string $responseUrl): RequestDTOInterface
     {
         $this->responseUrl = $responseUrl;
         return $this;
     }
-    
+
     public function getResponseUrl(): ?string
     {
         return $this->responseUrl;
     }
-    
+
     public function setAcceptableInfrastructure(?string $acceptableInfrastructure): RequestDTOInterface
     {
         $this->acceptableInfrastructure = $acceptableInfrastructure;
         return $this;
     }
-    
+
     public function getAcceptableInfrastructure(): ?string
     {
         return $this->acceptableInfrastructure;

--- a/src/HttpClient/DTO/Request/Traits/WithFileDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithFileDTO.php
@@ -9,47 +9,47 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithFileDTO
 {
     private ?string $fileName = null;
-    
+
     private ?string $content = null;
-    
+
     private ?string $fileDigest = null;
-    
+
     public function setFileName(?string $fileName): RequestDTOInterface
     {
         $this->fileName = $fileName;
         return $this;
     }
-    
+
     public function getFileName(): ?string
     {
         return $this->fileName;
     }
-    
+
     public function setContent(?string $content): RequestDTOInterface
     {
         $this->content = $content;
         return $this;
     }
-    
+
     public function getContent(): ?string
     {
         return $this->content;
     }
-    
+
     public function setFileDigest(?string $fileDigest): RequestDTOInterface
     {
         $this->fileDigest = $fileDigest;
         return $this;
     }
-    
+
     public function getFileDigest(): ?string
     {
         return $this->fileDigest;
     }
-    
+
     public function withFileDigest(string $fileDigest): RequestDTOInterface
     {
-        
+
         $fileDTO = clone $this;
 
         $fileDTO->setFileDigest($fileDigest);

--- a/src/HttpClient/DTO/Request/Traits/WithLocaleDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithLocaleDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithLocaleDTO
 {
     private ?string $locale = null;
-    
+
     public function setLocale(?string $locale): RequestDTOInterface
     {
         $this->locale = $locale;
         return $this;
     }
-    
+
     public function getLocale(): ?string
     {
         return $this->locale;

--- a/src/HttpClient/DTO/Request/Traits/WithSignatureDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithSignatureDTO.php
@@ -9,18 +9,18 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithSignatureDTO
 {
     private string $signature;
-    
+
     public function setSignature(string $signature): RequestDTOInterface
     {
         $this->signature = $signature;
         return $this;
     }
-    
+
     public function getSignature(): ?string
     {
         return $this->signature;
     }
-    
+
     public function withSignature(string $signature): RequestDTOInterface
     {
         $signatureDTO = clone $this;
@@ -29,7 +29,7 @@ trait WithSignatureDTO
 
         return $signatureDTO;
     }
-    
+
     public function withBased64Signature(string $signature): RequestDTOInterface
     {
         $signatureDTO = clone $this;

--- a/src/HttpClient/DTO/Request/Traits/WithSignatureDisplayPropertiesDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithSignatureDisplayPropertiesDTO.php
@@ -9,54 +9,54 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithSignatureDisplayPropertiesDTO
 {
 
-    
+
     private ?string $position = null;
-    
+
     private bool $displayValidity = false;
-    
+
     private ?string $signatureImageUrl = null;
-    
+
     private ?string $backgroundImageUrl = null;
-    
+
     public function setPosition(string $position): RequestDTOInterface
     {
         $this->position = $position;
         return $this;
     }
-    
+
     public function getPosition(): ?string
     {
         return $this->position;
     }
-    
+
     public function setDisplayValidity(bool $displayValidity): RequestDTOInterface
     {
         $this->displayValidity = $displayValidity;
         return $this;
     }
-    
+
     public function getDisplayValidity(): bool
     {
         return $this->displayValidity;
     }
-    
+
     public function setSignatureImageUrl(?string $signatureImageUrl): RequestDTOInterface
     {
         $this->signatureImageUrl = $signatureImageUrl;
         return $this;
     }
-    
+
     public function getSignatureImageUrl(): ?string
     {
         return $this->signatureImageUrl;
     }
-    
+
     public function setBackgroundImageUrl(?string $backgroundImageUrl): RequestDTOInterface
     {
         $this->backgroundImageUrl = $backgroundImageUrl;
         return $this;
     }
-    
+
     public function getBackgroundImageUrl(): ?string
     {
         return $this->backgroundImageUrl;

--- a/src/HttpClient/DTO/Request/Traits/WithSignatureMetadataDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithSignatureMetadataDTO.php
@@ -9,39 +9,39 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithSignatureMetadataDTO
 {
     private ?string $reason = null;
-    
+
     private ?string $location = null;
-    
+
     private ?string $contact = null;
-    
+
     public function setReason(?string $reason): RequestDTOInterface
     {
         $this->reason = $reason;
         return $this;
     }
-    
+
     public function getReason(): ?string
     {
         return $this->reason;
     }
-    
+
     public function setLocation(?string $location): RequestDTOInterface
     {
         $this->location = $location;
         return $this;
     }
-    
+
     public function getLocation(): ?string
     {
         return $this->location;
     }
-    
+
     public function setContact(?string $contact): RequestDTOInterface
     {
         $this->contact = $contact;
         return $this;
     }
-    
+
     public function getContact(): ?string
     {
         return $this->contact;

--- a/src/HttpClient/DTO/Request/Traits/WithSigningTypeDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithSigningTypeDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithSigningTypeDTO
 {
     private string $signingType;
-    
+
     public function setSigningType(string $signingType): RequestDTOInterface
     {
         $this->signingType = $signingType;
         return $this;
     }
-    
+
     public function getSigningType(): string
     {
         return $this->signingType;

--- a/src/HttpClient/DTO/Request/Traits/WithTransactionDTO.php
+++ b/src/HttpClient/DTO/Request/Traits/WithTransactionDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\RequestDTOInterface;
 trait WithTransactionDTO
 {
     private string $transactionId;
-    
+
     public function setTransactionId(string $transactionId): RequestDTOInterface
     {
         $this->transactionId = $transactionId;
         return $this;
     }
-    
+
     public function getTransactionId(): ?string
     {
         return $this->transactionId;

--- a/src/HttpClient/DTO/RequestDTOInterface.php
+++ b/src/HttpClient/DTO/RequestDTOInterface.php
@@ -7,10 +7,10 @@ namespace RegistruCentras\OneSign\HttpClient\DTO;
 interface RequestDTOInterface
 {
     public function toArray(): array;
-    
+
     public function __toString(): string;
-    
+
     public function withSignature(string $signature): RequestDTOInterface;
-    
+
     public function withBased64Signature(string $signature): RequestDTOInterface;
 }

--- a/src/HttpClient/DTO/Response/CancelResponseDTO.php
+++ b/src/HttpClient/DTO/Response/CancelResponseDTO.php
@@ -18,12 +18,12 @@ use Fig\Http\Message\StatusCodeInterface;
 final class CancelResponseDTO implements ResponseDTOInterface
 {
     use WithStatusDTO;
-    
+
     public function __construct(ResponseInterface $response)
     {
-        
+
         $httpStatus = ResponseMediator::getStatus($response);
-        
+
         switch ($httpStatus) {
             case StatusCodeInterface::STATUS_ACCEPTED:
                 $this->setStatus(CancelSigningResponseStatus::CANCELED);
@@ -33,21 +33,21 @@ final class CancelResponseDTO implements ResponseDTOInterface
                 break;
         }
     }
-    
+
     public function isFilesExists(): bool
     {
         return false;
     }
-    
+
     public function __toString(): string
     {
         $array = $this->toArray();
-        
+
         $arrayToXml = new ArrayToXml($array);
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
-    
+
     public function toArray(): array
     {
         return [];

--- a/src/HttpClient/DTO/Response/InitResponseDTO.php
+++ b/src/HttpClient/DTO/Response/InitResponseDTO.php
@@ -19,23 +19,23 @@ final class InitResponseDTO implements ResponseDTOInterface
     use WithSigningUrlDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     private array $response;
-    
+
     public function __construct(ResponseInterface $response)
     {
         $this->response = ResponseMediator::getSoapBody($response, 'InitOneSignResponse');
-                
+
         $this->setTransactionId($this->response['transactionId']);
         $this->setSigningUrl($this->response['signingUrl']);
         $this->setSignature((string)\base64_decode($this->response['signature'], true));
     }
-    
+
     public function isFilesExists(): bool
     {
         return false;
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Response/Result/FileDTO.php
+++ b/src/HttpClient/DTO/Response/Result/FileDTO.php
@@ -11,18 +11,18 @@ use RegistruCentras\OneSign\HttpClient\DTO\Response\Traits\WithFileDTO;
 final class FileDTO implements ResponseDTOInterface
 {
     use WithFileDTO;
-    
+
     public function __toString(): string
     {
         $array = $this->toArray();
-        
+
         unset($array['content']);
-        
+
         $arrayToXml = new ArrayToXml($array);
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Response/ResultResponseDTO.php
+++ b/src/HttpClient/DTO/Response/ResultResponseDTO.php
@@ -20,88 +20,88 @@ final class ResultResponseDTO implements ResponseDTOInterface
     use WithStatusDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     private array $response;
-    
+
     private FileDTO $file;
-    
+
     private ?string $signerCertificate = null;
-    
+
     private bool $signerCertificateTrusted = false;
-    
+
     public function __construct(ResponseInterface $response)
     {
         $this->response = ResponseMediator::getSoapBody($response, 'SigningResultResponse');
-  
+
         switch ($this->response['status']) {
             case SigningResponseStatus::SIGNED:
                 $file = $this->response['file'];
-            
+
                 $fileDTO = (new FileDTO())
                     ->setFileDigest((string)\base64_decode($file['fileDigest'], true))
                     ->setFileName($file['fileName'])
                     ->setContent((string)\base64_decode($file['content'], true))
                     ;
-              
+
                 $this->setFile($fileDTO);
                 $this->setSignerCertificate($this->response['signerCertificate']);
-                $this->setSignerCertificateTrusted($this->response['signerCertificateTrusted']==='true');
+                $this->setSignerCertificateTrusted($this->response['signerCertificateTrusted'] === 'true');
                 break;
             default:
                 $this->setSignerCertificateTrusted(false);
                 break;
         }
-        
+
         $this->setStatus($this->response['status']);
         $this->setSignature((string)\base64_decode($this->response['signature'], true));
     }
-    
+
     public function setFile(FileDTO $file): ResponseDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function isFilesExists(): bool
     {
         return isset($this->file);
     }
-    
+
     public function setSignerCertificate(string $signerCertificate): ResponseDTOInterface
     {
         $this->signerCertificate = $signerCertificate;
         return $this;
     }
-    
+
     public function getSignerCertificate(): ?string
     {
         return $this->signerCertificate;
     }
-    
+
     public function setSignerCertificateTrusted(bool $signerCertificateTrusted): ResponseDTOInterface
     {
         $this->signerCertificateTrusted = $signerCertificateTrusted;
         return $this;
     }
-    
+
     public function getSignerCertificateTrusted(): bool
     {
         return $this->signerCertificateTrusted;
     }
-    
+
     public function toArray(): array
     {
         $defaultArray = \array_filter([
             'status' => $this->getStatus(),
         ]);
-        
+
         $signedArray = [];
-        
+
         if ($this->getStatus() === SigningResponseStatus::SIGNED) {
             $signedArray = [
                 'signerCertificate' => $this->getSignerCertificate(),
@@ -110,7 +110,7 @@ final class ResultResponseDTO implements ResponseDTOInterface
                 'fileName' => $this->getFile()->getFileName(),
             ];
         }
-        
+
         return \array_filter(\array_merge($defaultArray, $signedArray));
     }
 }

--- a/src/HttpClient/DTO/Response/Seal/FileDTO.php
+++ b/src/HttpClient/DTO/Response/Seal/FileDTO.php
@@ -11,19 +11,19 @@ use RegistruCentras\OneSign\HttpClient\DTO\Response\Traits\WithFileDTO;
 final class FileDTO implements ResponseDTOInterface
 {
     use WithFileDTO;
-    
+
     public function __toString(): string
     {
-        
+
         $array = $this->toArray();
-        
+
         unset($array['content']);
-        
+
         $arrayToXml = new ArrayToXml($array);
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Response/SealResponseDTO.php
+++ b/src/HttpClient/DTO/Response/SealResponseDTO.php
@@ -20,79 +20,79 @@ final class SealResponseDTO implements ResponseDTOInterface
     use WithStatusDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     private array $response;
-    
+
     private FileDTO $file;
-    
+
     private string $signerCertificate;
-    
+
     private bool $signerCertificateTrusted;
-    
+
     public function __construct(ResponseInterface $response)
     {
-        
+
         $this->response = ResponseMediator::getSoapBody($response, 'SealResponse');
 
         switch ($this->response['status']) {
             case SigningResponseStatus::SIGNED:
                 $file = $this->response['file'];
-            
+
                 $fileDTO = (new FileDTO())
                     ->setFileDigest((string)\base64_decode($file['fileDigest'], true))
                     ->setFileName($file['fileName'])
                     ->setContent((string)\base64_decode($file['content'], true))
                     ;
-            
+
                 $this->setFile($fileDTO);
                 $this->setSignerCertificate($this->response['signerCertificate']);
-                $this->setSignerCertificateTrusted($this->response['signerCertificateTrusted']==='true');
-                
+                $this->setSignerCertificateTrusted($this->response['signerCertificateTrusted'] === 'true');
+
                 break;
         }
-        
+
         $this->setStatus($this->response['status']);
         $this->setSignature((string)\base64_decode($this->response['signature'], true));
     }
-    
+
     public function setFile(FileDTO $file): ResponseDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function isFilesExists(): bool
     {
         return isset($this->file);
     }
-    
+
     public function setSignerCertificate(string $signerCertificate): ResponseDTOInterface
     {
         $this->signerCertificate = $signerCertificate;
         return $this;
     }
-    
+
     public function getSignerCertificate(): string
     {
         return $this->signerCertificate;
     }
-    
+
     public function setSignerCertificateTrusted(bool $signerCertificateTrusted): ResponseDTOInterface
     {
         $this->signerCertificateTrusted = $signerCertificateTrusted;
         return $this;
     }
-    
+
     public function getSignerCertificateTrusted(): bool
     {
         return $this->signerCertificateTrusted;
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Response/TimestampResponseDTO.php
+++ b/src/HttpClient/DTO/Response/TimestampResponseDTO.php
@@ -18,50 +18,50 @@ final class TimestampResponseDTO implements ResponseDTOInterface
     use WithStatusDTO;
     use WithSignatureDTO;
     use Stringable;
-    
+
     private array $response;
-    
+
     private FileDTO $file;
-    
+
     public function __construct(ResponseInterface $response)
     {
         $this->response = ResponseMediator::getSoapBody($response, 'TimestampResponse');
-        
+
         switch ($this->response['status']) {
             case SigningResponseStatus::SIGNED:
                 $file = $this->response['file'];
-            
+
                 $fileDTO = (new FileDTO())
                     ->setFileDigest((string)\base64_decode($file['fileDigest'], true))
                     ->setFileName($file['fileName'])
                     ->setContent((string)\base64_decode($file['content'], true))
                     ;
-            
+
                 $this->setFile($fileDTO);
-                
+
                 break;
         }
-        
+
         $this->setStatus($this->response['status']);
         $this->setSignature((string)\base64_decode($this->response['signature'], true));
     }
-    
+
     public function setFile(FileDTO $file): ResponseDTOInterface
     {
         $this->file = $file;
         return $this;
     }
-    
+
     public function getFile(): FileDTO
     {
         return $this->file;
     }
-    
+
     public function isFilesExists(): bool
     {
         return isset($this->file);
     }
-    
+
     public function toArray(): array
     {
         return \array_filter([

--- a/src/HttpClient/DTO/Response/Traits/Stringable.php
+++ b/src/HttpClient/DTO/Response/Traits/Stringable.php
@@ -10,11 +10,11 @@ trait Stringable
 {
     public function __toString(): string
     {
-        
+
         $array = $this->toArray();
-        
+
         $arrayToXml = new ArrayToXml($array);
-        
+
         return \preg_replace("/<\\/?root(\\s+.*?>|>)/", "", $arrayToXml->dropXmlDeclaration()->toXml());
     }
 }

--- a/src/HttpClient/DTO/Response/Traits/WithFileDTO.php
+++ b/src/HttpClient/DTO/Response/Traits/WithFileDTO.php
@@ -9,44 +9,44 @@ use RegistruCentras\OneSign\HttpClient\DTO\ResponseDTOInterface;
 trait WithFileDTO
 {
     private ?string $fileName = null;
-    
+
     private ?string $content = null;
-    
+
     private ?string $fileDigest = null;
-    
+
     public function setFileName(string $fileName): ResponseDTOInterface
     {
         $this->fileName = $fileName;
         return $this;
     }
-    
+
     public function getFileName(): ?string
     {
         return $this->fileName;
     }
-    
+
     public function setContent(?string $content): ResponseDTOInterface
     {
         $this->content = $content;
         return $this;
     }
-    
+
     public function getContent(): ?string
     {
         return $this->content;
     }
-    
+
     public function setFileDigest(?string $fileDigest): ResponseDTOInterface
     {
         $this->fileDigest = $fileDigest;
         return $this;
     }
-    
+
     public function getFileDigest(): ?string
     {
         return $this->fileDigest;
     }
-    
+
     public function withFileDigest(string $fileDigest): ResponseDTOInterface
     {
         $fileDTO = clone $this;

--- a/src/HttpClient/DTO/Response/Traits/WithSignatureDTO.php
+++ b/src/HttpClient/DTO/Response/Traits/WithSignatureDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\ResponseDTOInterface;
 trait WithSignatureDTO
 {
     private ?string $signature = null;
-    
+
     public function setSignature(?string $signature): ResponseDTOInterface
     {
         $this->signature = $signature;
         return $this;
     }
-    
+
     public function getSignature(): ?string
     {
         return $this->signature;

--- a/src/HttpClient/DTO/Response/Traits/WithSigningUrlDTO.php
+++ b/src/HttpClient/DTO/Response/Traits/WithSigningUrlDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\ResponseDTOInterface;
 trait WithSigningUrlDTO
 {
     private string $signingUrl;
-    
+
     public function setSigningUrl(string $signingUrl): ResponseDTOInterface
     {
         $this->signingUrl = $signingUrl;
         return $this;
     }
-    
+
     public function getSigningUrl(): ?string
     {
         return $this->signingUrl;

--- a/src/HttpClient/DTO/Response/Traits/WithStatusDTO.php
+++ b/src/HttpClient/DTO/Response/Traits/WithStatusDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\ResponseDTOInterface;
 trait WithStatusDTO
 {
     private string $status;
-    
+
     public function setStatus(string $status): ResponseDTOInterface
     {
         $this->status = $status;
         return $this;
     }
-    
+
     public function getStatus(): ?string
     {
         return $this->status;

--- a/src/HttpClient/DTO/Response/Traits/WithTransactionDTO.php
+++ b/src/HttpClient/DTO/Response/Traits/WithTransactionDTO.php
@@ -9,13 +9,13 @@ use RegistruCentras\OneSign\HttpClient\DTO\ResponseDTOInterface;
 trait WithTransactionDTO
 {
     private string $transactionId;
-    
+
     public function setTransactionId(string $transactionId): ResponseDTOInterface
     {
         $this->transactionId = $transactionId;
         return $this;
     }
-    
+
     public function getTransactionId(): ?string
     {
         return $this->transactionId;

--- a/src/HttpClient/Message/RequestMediator.php
+++ b/src/HttpClient/Message/RequestMediator.php
@@ -13,7 +13,7 @@ final class RequestMediator
      * @var string
   */
     public const SOAP_NAMESPACE = 'ones';
-    
+
     private static function generateRoot(): array
     {
         return [
@@ -24,20 +24,20 @@ final class RequestMediator
             ],
         ];
     }
-    
+
     public static function generateRequestRawBody(RequestDTOInterface $requestDTO): string
     {
-        
+
         $array = [
             'soapenv:Header' => [],
             'soapenv:Body' => $requestDTO->toArray(),
         ];
 
         $arrayToXml = new ArrayToXml($array, self::generateRoot());
-        
+
         return $arrayToXml->dropXmlDeclaration()->toXml();
     }
-    
+
     public static function elementWithNamespace(string $element): string
     {
         return \sprintf('%s:%s', self::SOAP_NAMESPACE, $element);

--- a/src/HttpClient/Message/Response.php
+++ b/src/HttpClient/Message/Response.php
@@ -12,44 +12,44 @@ use RegistruCentras\OneSign\HttpClient\Util\Files;
 final class Response
 {
     private Client $client;
-    
+
     private ResponseDTOInterface $responseDTO;
-    
+
     public function __construct(Client $client)
     {
         $this->client = $client;
     }
-    
+
     public function get(ResponseDTOInterface $responseDTO): self
     {
         $this->responseDTO = $responseDTO;
         return $this;
     }
-    
+
     public function toDTO(): ResponseDTOInterface
     {
         return $this->responseDTO;
     }
-    
+
     public function validate(): self
     {
         $publicKey = $this->client->getPublicKey();
         $content = (string)$this->responseDTO;
         $signature = $this->responseDTO->getSignature();
-        
+
         Signatory::validate($this->client->getPublicKey(), $content, $signature);
         return $this;
     }
-    
+
     public function validateFiles(): self
     {
         if ($this->responseDTO->isFilesExists()) {
             $fileDigest = $this->responseDTO->getFile()->getFileDigest();
             $fileContent = $this->responseDTO->getFile()->getContent();
-        
+
             Files::validateDigest($fileContent, $fileDigest);
         }
-        
+
         return $this;
     }
 }

--- a/src/HttpClient/Message/Response/Status/CancelSigningResponseStatus.php
+++ b/src/HttpClient/Message/Response/Status/CancelSigningResponseStatus.php
@@ -10,7 +10,7 @@ final class CancelSigningResponseStatus
      * @var string
   */
     public const CANCELED = 'Canceled';
-    
+
     /**
      * @var string
   */

--- a/src/HttpClient/Message/Response/Status/SigningResponseStatus.php
+++ b/src/HttpClient/Message/Response/Status/SigningResponseStatus.php
@@ -10,12 +10,12 @@ final class SigningResponseStatus
      * @var string
   */
     public const SIGNED = 'Signed';
-    
+
     /**
      * @var string
   */
     public const CANCELED = 'Canceled';
-    
+
     /**
      * @var string
   */

--- a/src/HttpClient/Message/ResponseMediator.php
+++ b/src/HttpClient/Message/ResponseMediator.php
@@ -20,7 +20,7 @@ final class ResponseMediator
      * @var string
      */
     public const TEXT_XML_CONTENT_TYPE = 'text/xml;charset=utf-8';
-    
+
     /**
   * @var string
   */
@@ -37,9 +37,9 @@ final class ResponseMediator
         if ('' === $body) {
             return [];
         }
-        
+
         $headerLine = $response->getHeaderLine(self::CONTENT_TYPE_HEADER);
-        
+
         $errorMessage = 'The response content type was not %s, response content is %s.';
 
         if (0 !== \strpos($response->getHeaderLine(self::CONTENT_TYPE_HEADER), self::TEXT_XML_CONTENT_TYPE)) {
@@ -48,7 +48,7 @@ final class ResponseMediator
 
         return XmlArray::decode($body);
     }
-    
+
     public static function getErrorMessage(ResponseInterface $response): ?string
     {
         try {
@@ -60,7 +60,7 @@ final class ResponseMediator
 
         return \is_array($error) ? self::getMessageFromError($error) : null;
     }
-    
+
     private static function getMessageFromError(array $error): ?string
     {
         /** @var scalar|array */
@@ -94,23 +94,23 @@ final class ResponseMediator
 
         return (string) \strtok(\is_string($detail) ? $detail : JsonArray::encode($detail), "\n");
     }
-    
+
     public static function getStatus(ResponseInterface $response): int
     {
-        
+
         return $response->getStatusCode();
     }
-    
+
     public static function getSoapBody(ResponseInterface $response, string $element): array
     {
         return self::getContent($response)['SOAP-ENV:Body'][self::elementWithNamespace($element)];
     }
-    
+
     public static function getSoapErrorMessage(ResponseInterface $response): ?string
     {
         return self::getContent($response)['SOAP-ENV:Body']['SOAP-ENV:Fault']['faultstring']['@content'];
     }
-    
+
     public static function elementWithNamespace(string $element): string
     {
         return \sprintf('%s:%s', self::SOAP_NAMESPACE, $element);

--- a/src/HttpClient/Plugin/ExceptionThrower.php
+++ b/src/HttpClient/Plugin/ExceptionThrower.php
@@ -21,7 +21,7 @@ final class ExceptionThrower implements Plugin
     {
         return $next($request)->then(function (ResponseInterface $response): ResponseInterface {
             $status = $response->getStatusCode();
-            
+
             if ($status >= 400 && $status < 600) {
                 throw self::createException($response);
             }
@@ -33,21 +33,21 @@ final class ExceptionThrower implements Plugin
     private static function createException(ResponseInterface $response): ExceptionInterface
     {
         $status = $response->getStatusCode();
-        
+
         if (400 === $status || 422 === $status) {
             $errorMessage = ResponseMediator::getErrorMessage($response) ?? $response->getReasonPhrase();
-            
+
             return new ValidationFailedException($errorMessage, $status);
         }
-        
+
         if (500 === $status) {
             $errorMessage = ResponseMediator::getSoapErrorMessage($response) ?? $response->getReasonPhrase();
-            
+
             return new SoapErrorException($errorMessage, $status);
         }
-        
+
         $errorMessage =  ResponseMediator::getErrorMessage($response) ?? $response->getReasonPhrase();
-        
+
         return new RuntimeException($errorMessage, $status);
     }
 }

--- a/src/HttpClient/Plugin/SoapRequest.php
+++ b/src/HttpClient/Plugin/SoapRequest.php
@@ -11,12 +11,12 @@ use Psr\Http\Message\RequestInterface;
 final class SoapRequest implements Plugin
 {
     private string $soapAction;
-    
+
     public function __construct(string $soapAction)
     {
         $this->soapAction = $soapAction;
     }
-    
+
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $request = $request

--- a/src/HttpClient/Util/Files.php
+++ b/src/HttpClient/Util/Files.php
@@ -12,11 +12,11 @@ final class Files
     {
         return \hash('sha1', $content, true);
     }
-    
+
     public static function validateDigest(string $fileContent, string $fileDigest): void
     {
         $tempFileDigest = self::generateFileDigest($fileContent);
-        
+
         if ($fileDigest !== $tempFileDigest) {
             throw new FileValidationFailedException('Can not validate file by file digest!');
         }

--- a/src/HttpClient/Util/Signatory.php
+++ b/src/HttpClient/Util/Signatory.php
@@ -11,20 +11,20 @@ final class Signatory
     public static function sign(string $content, string $privateKey, string $passphrase = ''): string
     {
         $sign = '';
-        
+
         $key = \openssl_get_privatekey($privateKey, $passphrase);
-        
+
         \openssl_sign($content, $sign, $key);
-        
+
         return $sign;
     }
-    
+
     public static function validate(string $publicKey, string $content, string $signature): void
     {
         $publicKeyId = \openssl_pkey_get_public($publicKey);
-        
+
         $ok = \openssl_verify($content, $signature, $publicKeyId);
-        
+
         if ($ok === 0) {
             throw new ValidationFailedException((string)\openssl_error_string());
         }

--- a/tests/IntegrationSmokeTest.php
+++ b/tests/IntegrationSmokeTest.php
@@ -27,39 +27,39 @@ final class IntegrationSmokeTest extends TestCase
     use WithTestConfiguration;
     use WithTestTransaction;
     use WithTestSignatureConfiguration;
-    
+
     protected Client $client;
-    
+
     protected function setUp(): void
     {
         $this->client = self::setUpTestClient();
     }
-    
+
     public function testResultWithNotExistsTransactionId(): void
     {
         $this->expectException(SoapErrorException::class);
         $this->expectExceptionMessage('Invalid transaction ID.');
-        
+
         $response = $this->client
             ->result(self::setUpTestRandomTransaction())
             ;
     }
-    
+
     public function testCancelWithNotExistsTransactionId(): void
     {
         $this->expectException(SoapErrorException::class);
         $this->expectExceptionMessage('Invalid transaction ID.');
-        
+
         $response = $this->client
             ->cancel(self::setUpTestRandomTransaction())
             ;
     }
-    
+
     public function testInitWithMinimalInfoRelativePositionAndSignatureAsNotExistsImage(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
-        
+
         $relativePosition = (new RelativePosition())
             ->setPage(1)
             ->setX(RelativeX::CENTER)
@@ -70,19 +70,19 @@ final class IntegrationSmokeTest extends TestCase
             ->setSignatureImageUrl('https://www.registrucentras.lt/img/logo/rcrc.jpg')
             ->setBackgroundImageUrl('https://www.registrucentras.lt/img/logo/rcrc.jpg')
             ;
-        
+
         $signatureConfiguration = (new SignatureConfiguration())
             ->setDisplayProperties($relativePosition)
             ;
-            
+
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -34,284 +34,284 @@ final class IntegrationTest extends TestCase
     use WithTestConfiguration;
     use WithTestTransaction;
     use WithTestSignatureConfiguration;
-    
+
     protected Client $client;
-    
+
     protected Client $clientWithoutPass;
-    
+
     protected function setUp(): void
     {
         $this->client = self::setUpTestClient();
         $this->clientWithoutPass = self::setUpTestClientWithoutPass();
     }
-    
+
     public function testInitWithMinimalInfo(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithClientWithoutPass(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->clientWithoutPass
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithTimestamp(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setSigningType(SigningType::SIGNATURE_WITH_TIMESTAMP)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithTimestampOcsp(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setSigningType(SigningType::SIGNATURE_WITH_TIMESTAMP_OCSP)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoMobileSigning(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setAcceptableInfrastructure(AcceptableInfrastructure::MOBILE)
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoStationarySigning(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setAcceptableInfrastructure(AcceptableInfrastructure::STATIONARY)
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithLtLocale(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setLocale(Locale::LT)
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithEnLocale(): string
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
-        
+
         $configuration = (new Configuration())
             ->setResponseUrl('http://aaaa')
             ->setLocale(Locale::EN)
             ->setSigningType(SigningType::SIGNATURE)
             ;
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoWithSigner(): string
     {
         $noSigner = self::setUpTestSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestEmptySignatureConfiguration();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
-        
+
         return $response->getTransactionId();
     }
-    
+
     public function testInitWithMinimalInfoAndMetadata(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithMetadata();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoAndHiddenPosition(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithHiddenPosition();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoAndRelativePositionInLeftAndTop(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithRelativePositionInLeftAndTop();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoAndRelativePositionInCenter(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithRelativePositionInCenter();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoRelativePositionAndSignatureAsImage(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
-        
+
         $relativePosition = (new RelativePosition())
             ->setPage(1)
             ->setX(RelativeX::CENTER)
@@ -322,27 +322,27 @@ final class IntegrationTest extends TestCase
             ->setSignatureImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ->setBackgroundImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ;
-        
+
         $signatureConfiguration = (new SignatureConfiguration())
             ->setDisplayProperties($relativePosition)
             ;
-            
+
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoRelativeAbsoluteAndSignatureAsImage(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
-        
+
         $absolutePosition = (new AbsolutePosition())
             ->setPage(1)
             ->setX('2cm')
@@ -353,81 +353,81 @@ final class IntegrationTest extends TestCase
             ->setSignatureImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ->setBackgroundImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ;
-        
+
         $signatureConfiguration = (new SignatureConfiguration())
             ->setDisplayProperties($absolutePosition)
             ;
 
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoRelativeNamedAndSignatureAsImage(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
-        
+
          $namedPosition = (new NamedPosition())
             ->setFieldName('signature1')
             ->setDisplayValidity(true)
             ->setSignatureImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ->setBackgroundImageUrl('https://www.registrucentras.lt/img/logo/rc.jpg')
             ;
-        
+
         $signatureConfiguration = (new SignatureConfiguration())
             ->setDisplayProperties($namedPosition)
             ;
 
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoAndAbsolutePosition(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithAbsolutePosition();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testInitWithMinimalInfoAndNamedPosition(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $signatureConfiguration = self::setUpTestSignatureConfigurationWithNamedPosition();
         $configuration = self::setUpTestConfiguration();
-        
+
         $response = $this->client
             ->init($noSigner, $testFile, $signatureConfiguration, $configuration)
             ;
-            
+
         $this->assertIsString($response->getTransactionId());
-        
+
         $this->assertIsString($response->getSigningUrl());
     }
-    
+
     public function testSeal(): void
     {
         $response = $this->client
@@ -436,64 +436,64 @@ final class IntegrationTest extends TestCase
 
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     public function testTimestampWithoutSignerAndLocale(): void
     {
         $response = $this->client
             ->timestamp(self::setUpTestWithoutSigner(), self::setUpTestFile(), self::setUpTestEmptyConfiguration())
             ;
-        
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     public function testTimestampWithSigner(): void
     {
         $response = $this->client
             ->timestamp(self::setUpTestSigner(), self::setUpTestFile(), self::setUpTestEmptyConfiguration())
             ;
-        
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     public function testTimestampWithLtLocale(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $configuration = self::setUpTestConfigurationWithLocale(Locale::LT);
-        
+
         $response = $this->client
             ->timestamp($noSigner, $testFile, $configuration)
             ;
-        
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     public function testTimestampWithEnLocale(): void
     {
         $noSigner = self::setUpTestWithoutSigner();
         $testFile = self::setUpTestFile();
         $configuration = self::setUpTestConfigurationWithLocale(Locale::EN);
-        
+
         $response = $this->client
             ->timestamp($noSigner, $testFile, $configuration)
             ;
-        
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     public function testTimestampWithSignerAndLocale(): void
     {
         $noSigner = self::setUpTestSigner();
         $testFile = self::setUpTestFile();
         $configuration = self::setUpTestConfigurationWithLocale(Locale::LT);
-        
+
         $response = $this->client
             ->timestamp($noSigner, $testFile, $configuration)
             ;
-        
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }
-    
+
     /*public function testSignedResult(): void
     {
         $response = $this->client
@@ -502,7 +502,7 @@ final class IntegrationTest extends TestCase
 
         $this->assertEquals($response->getStatus(), SigningResponseStatus::SIGNED);
     }*/
-    
+
     /**
      * @depends testInitWithMinimalInfo
      */
@@ -511,10 +511,10 @@ final class IntegrationTest extends TestCase
         $response = $this->client
             ->result(self::setUpTestTransaction($transactionId))
             ;
-            
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::IN_PROGRESS);
     }
-    
+
     /**
      * @depends testInitWithMinimalInfo
      */
@@ -523,10 +523,10 @@ final class IntegrationTest extends TestCase
         $response = $this->client
             ->cancel(self::setUpTestTransaction($transactionId))
             ;
-            
+
         $this->assertEquals($response->getStatus(), CancelSigningResponseStatus::CANCELED);
     }
-    
+
     /**
      * @depends testInitWithMinimalInfo
      */
@@ -535,7 +535,7 @@ final class IntegrationTest extends TestCase
         $response = $this->client
             ->result(self::setUpTestTransaction($transactionId))
             ;
-            
+
         $this->assertEquals($response->getStatus(), SigningResponseStatus::CANCELED);
     }
 }

--- a/tests/MockedClient.php
+++ b/tests/MockedClient.php
@@ -21,7 +21,7 @@ final class MockedClient
 
     private static function createResponseFactory(ResponseInterface $response): ResponseFactoryInterface
     {
-        return new class($response) implements ResponseFactoryInterface {
+        return new class ($response) implements ResponseFactoryInterface {
             private $response;
 
             public function __construct(ResponseInterface $response)

--- a/tests/Traits/WithTestClient.php
+++ b/tests/Traits/WithTestClient.php
@@ -10,7 +10,7 @@ trait WithTestClient
 {
     public static function setUpTestClient(): Client
     {
-        
+
         $client = new Client();
 
         $client->configure(
@@ -20,13 +20,13 @@ trait WithTestClient
             \getenv('ONESIGN_PRIVATE_KEY_PASSPHRASE'),
             \str_replace('||', "\n", \getenv('ONESIGN_PUBLIC_KEY'))
         );
-        
+
         return $client;
     }
-    
+
     public static function setUpTestClientWithoutPass(): Client
     {
-        
+
         $client = new Client();
 
         $client->configure(
@@ -36,7 +36,7 @@ trait WithTestClient
             '',
             \str_replace('||', "\n", \getenv('ONESIGN_PUBLIC_KEY'))
         );
-        
+
         return $client;
     }
 }

--- a/tests/Traits/WithTestConfiguration.php
+++ b/tests/Traits/WithTestConfiguration.php
@@ -17,14 +17,14 @@ trait WithTestConfiguration
             ->setSigningType(SigningType::SIGNATURE)
             ;
     }
-    
+
     public static function setUpTestConfigurationWithLocale(string $locale): Configuration
     {
         return (new Configuration())
             ->setLocale($locale)
             ;
     }
-    
+
     public static function setUpTestEmptyConfiguration(): Configuration
     {
         return new Configuration();

--- a/tests/Traits/WithTestSignatureConfiguration.php
+++ b/tests/Traits/WithTestSignatureConfiguration.php
@@ -20,34 +20,34 @@ trait WithTestSignatureConfiguration
         return (new SignatureConfiguration())
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithMetadata(): SignatureConfiguration
     {
-        
+
         $metadata = (new Metadata())
             ->setReason('Fake reason')
             ->setLocation('Vilnius')
             ->setContact('Registų centras')
             ;
-        
+
         return (new SignatureConfiguration())
             ->setMetadata($metadata)
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithHiddenPosition(): SignatureConfiguration
     {
-        
+
         $hiddenPosition = new HiddenPosition();
-        
+
         return (new SignatureConfiguration())
             ->setDisplayProperties($hiddenPosition)
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithRelativePositionInLeftAndTop(): SignatureConfiguration
     {
-        
+
         $relativePosition = (new RelativePosition())
             ->setPage(1)
             ->setX(RelativeX::LEFT)
@@ -55,15 +55,15 @@ trait WithTestSignatureConfiguration
             ->setWidth('8cm')
             ->setHeight('4cm')
             ;
-        
+
         return (new SignatureConfiguration())
             ->setDisplayProperties($relativePosition)
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithRelativePositionInCenter(): SignatureConfiguration
     {
-        
+
         $relativePosition = (new RelativePosition())
             ->setPage(1)
             ->setX(RelativeX::CENTER)
@@ -71,15 +71,15 @@ trait WithTestSignatureConfiguration
             ->setWidth('8cm')
             ->setHeight('4cm')
             ;
-        
+
         return (new SignatureConfiguration())
             ->setDisplayProperties($relativePosition)
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithAbsolutePosition(): SignatureConfiguration
     {
-        
+
         $absolutePosition = (new AbsolutePosition())
             ->setPage(1)
             ->setX('2cm')
@@ -87,19 +87,19 @@ trait WithTestSignatureConfiguration
             ->setWidth('8cm')
             ->setHeight('4cm')
             ;
-        
+
         return (new SignatureConfiguration())
             ->setDisplayProperties($absolutePosition)
             ;
     }
-    
+
     public static function setUpTestSignatureConfigurationWithNamedPosition(): SignatureConfiguration
     {
-        
+
         $namedPosition = (new NamedPosition())
             ->setFieldName('signature1')
             ;
-        
+
         return (new SignatureConfiguration())
             ->setDisplayProperties($namedPosition)
             ;

--- a/tests/Traits/WithTestSigner.php
+++ b/tests/Traits/WithTestSigner.php
@@ -14,7 +14,7 @@ trait WithTestSigner
             ->setPersonalCode($personalCode)
             ;
     }
-    
+
     public static function setUpTestWithoutSigner(): Signer
     {
         return (new Signer())

--- a/tests/Traits/WithTestTransaction.php
+++ b/tests/Traits/WithTestTransaction.php
@@ -14,13 +14,13 @@ trait WithTestTransaction
             ->setTransactionId($transactionId)
             ;
     }
-    
+
     public static function setUpTestRandomTransaction(): Transaction
     {
         return self::setUpTestTransaction((string)\random_int(111111, 999999))
             ;
     }
-    
+
     public static function getSignedTransaction(): Transaction
     {
         return self::setUpTestTransaction('455371')


### PR DESCRIPTION
`README.md` states that the code is `PSR12` compliant, but `phpcs` config had `PSR2` standard instead.
Changed standard in config and applied `phpcbf` fixes (looks like spaces on empty lines were the only incompatibility).