### PR TITLE
fix(validate): correct handling of openssl_verify return value

### DIFF
--- a/src/HttpClient/Util/Signatory.php
+++ b/src/HttpClient/Util/Signatory.php
@@ -25,7 +25,7 @@ final class Signatory
 
         $ok = \openssl_verify($content, $signature, $publicKeyId);
 
-        if ($ok === 0) {
+        if ($ok !== 1) {
             throw new ValidationFailedException((string)\openssl_error_string());
         }
     }


### PR DESCRIPTION
Update signature validation to check `$ok !== 1` instead of `$ok === 0`. `openssl_verify` returns:
- 1 → signature is valid
- 0 → signature is invalid
- -1/false → error occurred

This change ensures errors are not misclassified and invalid signatures are properly detected.